### PR TITLE
[BUGFIX] Running in 1-tick

### DIFF
--- a/2006Redone Server/src/main/java/com/rebotted/net/packets/impl/ClickingButtons.java
+++ b/2006Redone Server/src/main/java/com/rebotted/net/packets/impl/ClickingButtons.java
@@ -1167,11 +1167,11 @@ public class ClickingButtons implements PacketType {
 				player.getDialogueHandler().sendDialogues(3041, 0);
 			}
 			player.getPacketSender().sendConfig(173, 1);
-			player.isRunning2 = true;
+			player.isRunning = true;
 			break;
 
 		case 152:
-			player.isRunning2 = false;
+			player.isRunning = false;
 			player.getPacketSender().sendConfig(173, 0);
 			break;
 


### PR DESCRIPTION
Running will now start/stop when you press the buttons and not on the next walking packet

Related to issue #152