### PR TITLE
Mining Fixes | Yell Command Fix

### DIFF
--- a/2006Redone Server/src/main/java/com/rebotted/game/content/skills/core/Mining.java
+++ b/2006Redone Server/src/main/java/com/rebotted/game/content/skills/core/Mining.java
@@ -37,8 +37,8 @@ public class Mining {
 		{1265, 1, 1, 625}, //Bronze
 		{1267, 1, 2, 626}, //Iron
 		{1269, 6, 3, 627}, //Steel
-		{1271, 31, 5, 629}, //Addy
-		{1273, 21, 4, 628}, //Mithril
+		{1273, 21, 4, 629}, //Mithril
+		{1271, 31, 5, 628}, //Addy
 		{1275, 41, 6, 624}, //Rune
 	};
 
@@ -158,6 +158,7 @@ public class Mining {
 			public void execute(CycleEventContainer container) {
 				if (c.isMining) {
 					c.startAnimation(Pick_Settings[c.miningAxe][3]);
+					c.getPacketSender().sendSound(432, 100, 0);
 				} else {
 					container.stop();
 				}
@@ -202,6 +203,7 @@ public class Mining {
 		}
 
 		player.startAnimation(Pick_Settings[player.miningAxe][3]);
+		player.getPacketSender().sendSound(432, 100, 0);
 		player.isMining = true;
 		repeatAnimation(player);
 		player.rockX = objectX;

--- a/2006Redone Server/src/main/java/com/rebotted/net/packets/impl/Commands.java
+++ b/2006Redone Server/src/main/java/com/rebotted/net/packets/impl/Commands.java
@@ -54,7 +54,7 @@ public class Commands implements PacketType {
                 if (player.playerRights <= 1) {
                     delay = 30000;
                 }
-                if (!AntiSpam.blockedWords(player, playerCommand.substring(5), true)) {
+                if (!AntiSpam.blockedWords(player, arguments[0].substring(5), true)) {
                     return;
                 }
                 if (Connection.isMuted(player)) {


### PR DESCRIPTION
### Description
**Mining**
- Fixed Mining Pickaxes: When using a mith pickaxe it showed it using addy and vise versa.
- Added Mining Sounds.

**Commands**
- Fixed Yell Command: It was originally using playerCommand.substring(5) which would return index out of bounds. (Changed to argument[0].