### PR TITLE
Lost City Required for Dragon Longsword / Dagger

### DIFF
--- a/2006Redone Server/src/main/java/com/rebotted/game/items/ItemAssistant.java
+++ b/2006Redone Server/src/main/java/com/rebotted/game/items/ItemAssistant.java
@@ -1405,8 +1405,8 @@ public class ItemAssistant {
 				case 5680:
 				case 5698:
 				case 1305:
-					if (player.spiritTree == false && player.playerRights != 3) {
-						player.getPacketSender().sendMessage("You need to beat the tree spirit to wield this weapon.");
+					if (player.lostCity != 3 && player.playerRights != 3) {
+						player.getPacketSender().sendMessage("You must have completed the Lost City quest to equip this weapon.");
 						canWearItem = false;
 					}
 			}


### PR DESCRIPTION
- Lost City completion is required to equip dragon longsword and dragon dagger