### PR TITLE
Fixed firemaking log duplication

### DIFF
--- a/2006Redone Server/src/main/java/com/rebotted/game/content/skills/firemaking/Firemaking.java
+++ b/2006Redone Server/src/main/java/com/rebotted/game/content/skills/firemaking/Firemaking.java
@@ -77,6 +77,7 @@ public class Firemaking {
 				} else {
 					if (groundObject == false) {
 						c.getItemAssistant().deleteItem(logId, c.getItemAssistant().getItemSlot(logId), 1);
+						GameEngine.itemHandler.createGroundItem(c, logId, c.absX, c.absY, 1, c.playerId);
 					}
 				}
 				final boolean walk;
@@ -131,6 +132,9 @@ public class Firemaking {
 									}, 2);
 							container.stop();
 						} else {
+							c.isFiremaking = false;
+							stopFiremaking(c);
+							container.stop();
 							return;
 						}
 					}


### PR DESCRIPTION
If you lit a fire too soon to your last fire you could light a fire and keep your log.
Also when this happens sometimes it would delete the log that you try to light and there is no fire.