### PR TITLE
Fixed wrong smelting response when trading & made full iron helm use 2 bars

### DIFF
--- a/2006Redone Server/src/main/java/com/rebotted/game/content/skills/smithing/Smelting.java
+++ b/2006Redone Server/src/main/java/com/rebotted/game/content/skills/smithing/Smelting.java
@@ -124,7 +124,7 @@ public class Smelting extends SkillHandler {
 							c.getItemAssistant().deleteItem(c.playerSkillProp[13][4], c.playerSkillProp[13][5]);
 						}
 
-						if (c.playerSkillProp[13][3] == IRON && c.playerSkillProp[13][4] == -1) {
+						if (c.playerSkillProp[13][3] == IRON && c.playerSkillProp[13][4] == -1 && c.isSmelting) {
 							// Ring of forging
 							if (c.playerEquipment[c.playerRing] == 2568) {
 								c.getPlayerAssistant().addSkillXP(c.playerSkillProp[13][2], c.playerSmithing);
@@ -140,11 +140,11 @@ public class Smelting extends SkillHandler {
 									c.getPacketSender().sendMessage("You failed to smelt the iron bar.");
 								}
 							}
-						} else if (c.playerSkillProp[13][3] == GOLD && c.playerEquipment[c.playerHands] == 776) {
+						} else if (c.playerSkillProp[13][3] == GOLD && c.playerEquipment[c.playerHands] == 776 && c.isSmelting) {
 							c.getPacketSender().sendMessage("You receive a " + ItemAssistant.getItemName(c.playerSkillProp[13][6]).toLowerCase() + ".");
 							c.getPlayerAssistant().addSkillXP(56.2,	c.playerSmithing);
 							c.getItemAssistant().addItem(c.playerSkillProp[13][6], 1);// item
-						} else {
+						} else if (c.isSmelting){
 							c.getPacketSender().sendMessage("You receive a " + ItemAssistant.getItemName(c.playerSkillProp[13][6]).toLowerCase() + ".");
 							c.getPlayerAssistant().addSkillXP(c.playerSkillProp[13][2], c.playerSmithing);
 							c.getItemAssistant().addItem(c.playerSkillProp[13][6], 1);// item

--- a/2006Redone Server/src/main/java/com/rebotted/game/content/skills/smithing/SmithingData.java
+++ b/2006Redone Server/src/main/java/com/rebotted/game/content/skills/smithing/SmithingData.java
@@ -40,7 +40,7 @@ public enum SmithingData {
     IRON_SCIM(1323, 25, 20, 2),
     IRON_LONG(1293, 50, 21, 2),
     IRON_KNIFE(863, 25, 22, 1),
-    IRON_FULL(1153, 50, 22, 1),
+    IRON_FULL(1153, 50, 22, 2),
     IRON_SQ(1175, 50, 23, 2),
     IRON_HAMMER(1335, 38, 24, 3),
     IRON_BATTLEAXE(1363, 75, 25, 3),


### PR DESCRIPTION
If you make a trade request while smelting the game responds:
"You have received an unarmed"