### PR TITLE
Fix call to NpcAggressive.isAggressive

### DIFF
--- a/2006Redone Server/src/main/java/com/rebotted/game/npcs/NpcHandler.java
+++ b/2006Redone Server/src/main/java/com/rebotted/game/npcs/NpcHandler.java
@@ -557,7 +557,7 @@ public class NpcHandler {
 
                 Player client = (Client) PlayerHandler.players[NpcData.getCloseRandomPlayer(i)];
                 if (client != null) {
-                    boolean aggressive = (NpcAggressive.isAggressive(npcs[i].npcType) || getNpcListCombat(npcs[i].npcType) * 2 > client.combatLevel && getNpcListAggressive(npcs[i].npcType));
+                    boolean aggressive = (NpcAggressive.isAggressive(i) || getNpcListCombat(npcs[i].npcType) * 2 > client.combatLevel && getNpcListAggressive(npcs[i].npcType));
                     if (aggressive && !npcs[i].underAttack && !npcs[i].isDead && npcs[i].MaxHP > 0) {
                         npcs[i].killerId = NpcData.getCloseRandomPlayer(i);
                     }


### PR DESCRIPTION
Potential aggression regression :)

#416 appears to have overzealously changed `NpcAggressive.isAggressive(i)` to `NpcAggressive.isAggressive(npcs[i].npcType)`.
This should not by needed because `i` within `NpcAggressive.isAggressive` is always passed into `NpcHandler.npcs[i]`
https://github.com/2006rebotted/2006rebotted/blob/12951be95407d172b91d06ff57e8376c8d71fb58/2006Redone%20Server/src/main/java/com/rebotted/game/content/combat/npcs/NpcAggressive.java#L22-L24
https://github.com/2006rebotted/2006rebotted/blob/12951be95407d172b91d06ff57e8376c8d71fb58/2006Redone%20Server/src/main/java/com/rebotted/game/content/minigames/FightCaves.java#L396-L397

As a sidenote, I noticed the issue within the Lumbridge cow field where some of the cows were aggresive on a local server current with master.

I wasn't sure if this resolves the need for `try {} catch` in `NpcAggressive.isAggressive` but suspect it may.
