### PR TITLE
Fix bug where leveling up while Smelting would consume ores.

### DIFF
--- a/2006Redone Server/src/main/java/com/rebotted/game/content/skills/SkillHandler.java
+++ b/2006Redone Server/src/main/java/com/rebotted/game/content/skills/SkillHandler.java
@@ -63,8 +63,8 @@ public class SkillHandler {
 			player.isSmithing = false;
 		} else if (isSkilling[12]) {// crafting
 			isSkilling[12] = false;
-		} else if (player.isSmelting) {
-			player.isSmelting = false;
+		} else if (player.isSmelting || player.playerSkilling[13]) {// smelting
+			Smelting.resetSmelting(player);
 		} else if (player.isCrafting) {
 			player.isCrafting = false;
 		} else if (player.isPotionMaking) {// herblore
@@ -77,8 +77,6 @@ public class SkillHandler {
 			player.isPotCrafting = false;
 		} else if (player.playerIsCooking) {// cooking
 			Cooking.setCooking(player, false);
-		} else if (player.playerSkilling[13]) {// smelting
-			Smelting.resetSmelting(player);
 		}
 	}
 
@@ -96,8 +94,8 @@ public class SkillHandler {
 			player.isSmithing = false;
 		} else if (isSkilling[12]) {// crafting
 			isSkilling[12] = false;
-		} else if (player.isSmelting) {
-			player.isSmelting = false;
+		} else if (player.isSmelting || player.playerSkilling[13]) {// smelting
+			Smelting.resetSmelting(player);
 		} else if (player.isCrafting) {
 			player.isCrafting = false;
 		} else if (player.isPotionMaking) {// herblore

--- a/2006Redone Server/src/main/java/com/rebotted/game/content/skills/smithing/Smelting.java
+++ b/2006Redone Server/src/main/java/com/rebotted/game/content/skills/smithing/Smelting.java
@@ -127,14 +127,14 @@ public class Smelting extends SkillHandler {
 						if (c.playerSkillProp[13][3] == IRON && c.playerSkillProp[13][4] == -1 && c.isSmelting) {
 							// Ring of forging
 							if (c.playerEquipment[c.playerRing] == 2568) {
-								c.getPlayerAssistant().addSkillXP(c.playerSkillProp[13][2], c.playerSmithing);
 								c.getItemAssistant().addItem(c.playerSkillProp[13][6], 1);// item
+								c.getPlayerAssistant().addSkillXP(c.playerSkillProp[13][2], c.playerSmithing);
 								c.getPacketSender().sendMessage("You receive an " + ItemAssistant.getItemName(c.playerSkillProp[13][6]).toLowerCase() + ".");
 
 							} else {
 								if (Misc.random(100) >= 50) {
-									c.getPlayerAssistant().addSkillXP(c.playerSkillProp[13][2], c.playerSmithing);
 									c.getItemAssistant().addItem(c.playerSkillProp[13][6], 1);// item
+									c.getPlayerAssistant().addSkillXP(c.playerSkillProp[13][2], c.playerSmithing);
 									c.getPacketSender().sendMessage("You receive an " + ItemAssistant.getItemName(c.playerSkillProp[13][6]).toLowerCase() + ".");
 								} else {
 									c.getPacketSender().sendMessage("You failed to smelt the iron bar.");
@@ -142,12 +142,12 @@ public class Smelting extends SkillHandler {
 							}
 						} else if (c.playerSkillProp[13][3] == GOLD && c.playerEquipment[c.playerHands] == 776 && c.isSmelting) {
 							c.getPacketSender().sendMessage("You receive a " + ItemAssistant.getItemName(c.playerSkillProp[13][6]).toLowerCase() + ".");
-							c.getPlayerAssistant().addSkillXP(56.2,	c.playerSmithing);
 							c.getItemAssistant().addItem(c.playerSkillProp[13][6], 1);// item
+							c.getPlayerAssistant().addSkillXP(56.2,	c.playerSmithing);
 						} else if (c.isSmelting){
 							c.getPacketSender().sendMessage("You receive a " + ItemAssistant.getItemName(c.playerSkillProp[13][6]).toLowerCase() + ".");
-							c.getPlayerAssistant().addSkillXP(c.playerSkillProp[13][2], c.playerSmithing);
 							c.getItemAssistant().addItem(c.playerSkillProp[13][6], 1);// item
+							c.getPlayerAssistant().addSkillXP(c.playerSkillProp[13][2], c.playerSmithing);
 						}
 
 						////////////////////// CHECKING //////////////////////

--- a/2006Redone Server/src/main/java/com/rebotted/game/content/skills/smithing/Smelting.java
+++ b/2006Redone Server/src/main/java/com/rebotted/game/content/skills/smithing/Smelting.java
@@ -127,15 +127,15 @@ public class Smelting extends SkillHandler {
 						if (c.playerSkillProp[13][3] == IRON && c.playerSkillProp[13][4] == -1 && c.isSmelting) {
 							// Ring of forging
 							if (c.playerEquipment[c.playerRing] == 2568) {
+								c.getPacketSender().sendMessage("You receive an " + ItemAssistant.getItemName(c.playerSkillProp[13][6]).toLowerCase() + ".");
 								c.getItemAssistant().addItem(c.playerSkillProp[13][6], 1);// item
 								c.getPlayerAssistant().addSkillXP(c.playerSkillProp[13][2], c.playerSmithing);
-								c.getPacketSender().sendMessage("You receive an " + ItemAssistant.getItemName(c.playerSkillProp[13][6]).toLowerCase() + ".");
 
 							} else {
 								if (Misc.random(100) >= 50) {
+									c.getPacketSender().sendMessage("You receive an " + ItemAssistant.getItemName(c.playerSkillProp[13][6]).toLowerCase() + ".");
 									c.getItemAssistant().addItem(c.playerSkillProp[13][6], 1);// item
 									c.getPlayerAssistant().addSkillXP(c.playerSkillProp[13][2], c.playerSmithing);
-									c.getPacketSender().sendMessage("You receive an " + ItemAssistant.getItemName(c.playerSkillProp[13][6]).toLowerCase() + ".");
 								} else {
 									c.getPacketSender().sendMessage("You failed to smelt the iron bar.");
 								}


### PR DESCRIPTION
Smelting doesn't stop when you level up. As it continues smelting you lose ores but do not gain bars.

### Step to reproduce
```
::tp 2973 3370
::skill 13 1
::empty
::item 436 10
::item 438 10
// smelt 10, get 10 bars
::empty
::item 436 10
::item 438 10
// smelt 10 again, it will level up, keep smelting, removing ore but not giving bars
```

### Problem
Leveling up will clear `isSmelting` preventing bars for being given but not hitting a condition to break out of the smelting loop.

### Fix
Utilize `resetSmelting` which, in addition to clearing `isSmelting` will cause it to end the smelting at one of these checks:
https://github.com/2006rebotted/2006rebotted/blob/fa167bacd3999efda6c7dff6d3d357cdb0731064/2006Redone%20Server/src/main/java/com/rebotted/game/content/skills/smithing/Smelting.java#L158-L165

Additionally, giving the item before the xp ensures that you receive the bar that levels you up.
