### PR TITLE
Fix gem check being rolled twice.

### DIFF
--- a/2006Redone Server/src/main/java/com/rebotted/game/content/skills/core/Mining.java
+++ b/2006Redone Server/src/main/java/com/rebotted/game/content/skills/core/Mining.java
@@ -17,20 +17,19 @@ public class Mining {
 	private static final int[] GLORIES = {1706, 1708, 1710, 1712};
 	
 	public boolean giveGem(Player player) {
+		int chance = 256;
 		for (int i = 0; i < GLORIES.length; i++) {
-			if ((player.playerEquipment[player.playerAmulet] == GLORIES[i] && Misc.random(86) == 1) || Misc.random(256) == 1) {
-				return true;
+			if (player.playerEquipment[player.playerAmulet] == GLORIES[i]) {
+				chance = 86;
 			}
 		}
-		return false;
+		return Misc.random(chance) == 1;
 	}
-	
+
 	public void obtainGem(Player player) {
 		int reward = RANDOM_GEMS[(int)(RANDOM_GEMS.length * Math.random())];
-		if (giveGem(player)) {
-			player.getItemAssistant().addItem(reward, 1);
-			player.getPacketSender().sendMessage("You found an " + ItemAssistant.getItemName(reward) + ".");
-		}
+		player.getItemAssistant().addItem(reward, 1);
+		player.getPacketSender().sendMessage("You found an " + ItemAssistant.getItemName(reward) + ".");
 	}
 	
 	public final int[][] Pick_Settings = {


### PR DESCRIPTION
`giveGem` roll is not needed in `obtainGem` because it is already checked in order to call `giveGem`.

https://github.com/2006rebotted/2006rebotted/blob/15ab6253499e5f5a38372a296d35aa30492dd6d6/2006Redone%20Server/src/main/java/com/rebotted/game/content/skills/core/Mining.java#L232-L238

Calling random inside the Glory loop results in multiple rolls, potentially hiding the double `giveGem` check.